### PR TITLE
Remove hint to broken theme

### DIFF
--- a/google-chrome/google-chrome.install
+++ b/google-chrome/google-chrome.install
@@ -8,7 +8,4 @@ post_install() {
 post_upgrade() {
 	  echo -e '\e[0;32m To have better integration with KaOS'
 	  echo -e '\e[0;32m Select Use GTK+ theme, this will follow your KDE settings'
-          echo -e '\e[0;32m Or download and use the KaOS specific theme crx:' 
-          echo -e '\e[0;32m http://sourceforge.net/projects/kaosx/files/sources/chrome-themes/theme1454128732.crx'
-          echo -e '\e[0;32m This google-chrome theme follows the KaOS color scheme and look \e[0m'
 }


### PR DESCRIPTION
I remove the hint about the crx theme, since that one is broken since like a year or so.