### PR TITLE
Add info about manual upload

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,5 +25,6 @@
 > …
 
 #### System info link created by Octopi > Tools > SysInfo
+(Upload to pastebin service such as [dpaste](https://dpaste.com))
 
 > …


### PR DESCRIPTION
Since the Octopi paste tool is not automatically uploading anymore, I add the info to this template. 