### PR TITLE
New Version MystiQ 0.4.0

### DIFF
--- a/mystiq/PKGBUILD
+++ b/mystiq/PKGBUILD
@@ -1,7 +1,7 @@
 
 pkgname=mystiq
 _pkgname=MystiQ
-pkgver=0.3.2
+pkgver=0.4.0
 pkgrel=1
 pkgdesc="FFmpeg GUI front-end based on Qt5."
 arch=('x86_64')


### PR DESCRIPTION
**Version 0.4.0 (2019-12-10)**

    Added French language Pack
    Changed the application icon
    Fixed: Adding Debian based distros build deps
    Fixed: Avoid pass crop parameters to ffmpeg when not changed the crop on configuration
    Changed logo to SVG format
    Feature: Replace the preview system with qtmultimedia
    Fixed: Remove more mplayer references.
    Fixed: some bugs on cut & crop dialogs.