### PR TITLE
New Release MystiQ 20.01.09

### DIFF
--- a/mystiq/PKGBUILD
+++ b/mystiq/PKGBUILD
@@ -1,7 +1,7 @@
 
 pkgname=mystiq
 _pkgname=MystiQ
-pkgver=0.4.0
+pkgver=20.01.09
 pkgrel=1
 pkgdesc="FFmpeg GUI front-end based on Qt5."
 arch=('x86_64')
@@ -11,7 +11,7 @@ depends=('qt5-declarative' 'qt5-multimedia' 'ffmpeg' 'libnotify' 'sox')
 makedepends=('qt5-tools')
 replaces=('qwinff')
 source=("https://github.com/llamaret/MystiQ/archive/v${pkgver}.tar.gz")
-md5sums=('31fb7c094e3902911b6e501b39d57c61')
+md5sums=('668b8d3fbb52cadf8e48df632aca0d6a')
 
 build() {
    cd ${_pkgname}-${pkgver}


### PR DESCRIPTION
Version 20.01.09
 - Changed version numbering system. Now we use the exact release date as version number.
 - Available an installer for Microsoft Windows systems
 - Added updated packages of FFmpeg, FFprobe and FFplay (only for Microsoft Windows)
 - Using Qt 5.14 (only Microsoft Windows)
 - Cleaned task wizard UI
 - It is now possible to reorder items in the initial list of items in taskwizard
 - Added Swedish language Pack
 - Added Italian language Pack