### PR TITLE
New Release: MystiQ 20.02.18

### DIFF
--- a/mystiq/PKGBUILD
+++ b/mystiq/PKGBUILD
@@ -1,7 +1,7 @@
 
 pkgname=mystiq
 _pkgname=MystiQ
-pkgver=20.01.22
+pkgver=20.02.18
 pkgrel=1
 pkgdesc="FFmpeg GUI front-end based on Qt5."
 arch=('x86_64')
@@ -11,7 +11,7 @@ depends=('qt5-declarative' 'qt5-multimedia' 'ffmpeg' 'libnotify' 'sox')
 makedepends=('qt5-tools')
 replaces=('qwinff')
 source=("https://github.com/llamaret/MystiQ/archive/v${pkgver}.tar.gz")
-md5sums=('85f0b29ff9fc535f2176ce3b58fdada9')
+md5sums=('4ac14b992f8f0c03adcf56cec0488e8e')
 
 build() {
    cd ${_pkgname}-${pkgver}


### PR DESCRIPTION
Version 20.02.18 (2020-02-16)
 - Added Chinese language Pack
 - Added Turkish language Pack
 - Added New Presets for Youtube and Devices
 - Added support for audio and video formats that were not included
 - Added Video Color to Black & White option
 - Added Horizontal & Vertical Flip options
 - Added Rotate options
 - Updated Sweden Language Pack
 - Now using Qt 5.14.1 (only Microsoft windows)
 - Now using FFmpeg 4.2.2 (only Microsoft Windows)
 - Added metainfo file (only GNU/Linux)