### PR TITLE
New MystiQ 20.03.23

### DIFF
--- a/mystiq/PKGBUILD
+++ b/mystiq/PKGBUILD
@@ -1,7 +1,7 @@
 
 pkgname=mystiq
 _pkgname=MystiQ
-pkgver=20.02.18
+pkgver=20.03.23
 pkgrel=1
 pkgdesc="FFmpeg GUI front-end based on Qt5."
 arch=('x86_64')
@@ -11,7 +11,7 @@ depends=('qt5-declarative' 'qt5-multimedia' 'ffmpeg' 'libnotify' 'sox')
 makedepends=('qt5-tools')
 replaces=('qwinff')
 source=("https://github.com/swl-x/MystiQ/archive/v${pkgver}.tar.gz")
-md5sums=('4ac14b992f8f0c03adcf56cec0488e8e')
+md5sums=('d6e3babb0be21ae7592f4c313cc6edac')
 
 build() {
    cd ${_pkgname}-${pkgver}


### PR DESCRIPTION

Version 20.03.18 (2020-03-18)

    Added stereoscopic filters for 3D video options
    Improved application update notification system
    Improved bugs report option
    Added Hungarian language Pack
    Added Indonesian language Pack
    Improved AppImage File (only GNU/Linux)
    New icons included to the graphical interface