### PR TITLE
Change scon's build options for godot

### DIFF
--- a/godot/PKGBUILD
+++ b/godot/PKGBUILD
@@ -2,7 +2,7 @@
 pkgname=godot
 pkgver=4.0.2
 _pkgver=4.0.2-stable
-pkgrel=1
+pkgrel=2
 pkgdesc="Full featured, open source, MIT licensed, game engine."
 arch=('x86_64')
 url="https://www.godotengine.org"
@@ -19,15 +19,16 @@ build() {
     # https://github.com/godotengine/godot/issues/7676
     #patch -p1 -i ${srcdir}/43bc27e2755f34017148097773da8a6988718aaf.diff
 
-    scons platform=x11 \
+    scons platform=linuxbsd \
           use_llvm=no \
-          target=template_release
+          target=editor \
+          production=yes
 }
 
 package() {
     cd ${pkgname}-${_pkgver}
 
-    install -Dm755 bin/godot.linuxbsd.template_release.x86_64 ${pkgdir}/usr/bin/godot
+    install -Dm755 bin/godot.linuxbsd.editor.x86_64 ${pkgdir}/usr/bin/godot
 
     install -Dm644 misc/dist/linux/org.godotengine.Godot.desktop ${pkgdir}/usr/share/applications/godot.desktop
     install -Dm644 icon.svg ${pkgdir}/usr/share/pixmaps/godot.svg  


### PR DESCRIPTION
Currently godot throws an error message whenever is launched the editor

```
$ /usr/bin/godot
Error: Couldn't load project data at path ".". Is the .pck file missing?
If you've renamed the executable, the associated .pck file should also be renamed to match the executable's name (without the extension).
warning: queue 0xdbec60 destroyed while proxies still attached:
  wl_registry@16 still attached
warning: queue 0xdc0350 destroyed while proxies still attached:
  wl_display@1 still attached

```